### PR TITLE
Ignore Sonos Sub

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,7 +10,7 @@ var Nicercast = require('nicercast');
 console.log('Searching for Sonos devices on network...');
 sonos.search(function(device, model) {
 
-  if (model === 'BR100') return; // ignore Sonos Bridge device
+  if (model === 'BR100' || model === 'ANVIL') return; // ignore Sonos Bridge and Sub device
   device.getZoneAttrs(function(err, zoneAttrs) {
     if (err) throw err;
 
@@ -57,4 +57,3 @@ sonos.search(function(device, model) {
   });
 
 });
-


### PR DESCRIPTION
I added the Sonos Sub ('ANVIL') to the list of ignored devices as it can't be a standalone player and is always linked to another Sonos device. Streaming audio to the sub directly does not work.
