### PR TITLE
adding support for manual setup of Sonos devices 

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,96 @@ flags.defineBoolean('diagnostics', false, 'run diagnostics utility');
 flags.defineBoolean('version', false, 'return version number');
 flags.defineInteger('timeout', 5, 'disconnect timeout (in seconds)');
 flags.defineBoolean('verbose', false, 'show verbose output');
+flags.defineStringList('devices', [], 'a comma seperated list of IP[:port] values where Sonos devices can be found, disables discovery')
 flags.parse();
+
+var setupSonos = function(device, model) {
+
+	if (model === 'BR100' || model === 'ANVIL') return; // ignore Sonos Bridge and Sub device
+
+	device.getZoneAttrs(function(err, zoneAttrs) {
+	  if (err) throw err;
+
+	  var deviceName = zoneAttrs.CurrentZoneName;
+
+	  console.log('Setting up AirSonos for', deviceName, '{' + device.host + ':' + device.port + '}');
+
+	  var airplayServer = new NodeTunes({
+		serverName: deviceName + ' (AirSonos)',
+		verbose: flags.get('verbose'),
+		controlTimeout: flags.get('timeout')
+	  });
+
+	  var clientName = 'AirSonos';
+	  airplayServer.on('clientNameChange', function(name) {
+		clientName = 'AirSonos @ ' + name;
+	  });
+
+	  airplayServer.on('error', function(err) {
+		if (err.code === 415) {
+		  console.error('Warning!', err.message);
+		  console.error('AirSonos currently does not support codecs used by applications such as iTunes or AirFoil.');
+		  console.error('Progress on this issue: https://github.com/stephen/nodetunes/issues/1');
+		} else {
+		  console.error('Unknown error:');
+		  console.error(err);
+		}
+	  })
+
+	  airplayServer.on('clientConnected', function(audioStream) {
+
+		portastic.find({
+		  min : 8000,
+		  max : 8050,
+		  retrieve: 1
+		}, function(err, port) {
+		  if (err) throw err;
+
+		  var icecastServer = new Nicercast(audioStream, {
+			name: 'AirSonos @ ' + deviceName
+		  });
+
+		  airplayServer.on('metadataChange', function(metadata) {
+			if (metadata.minm)
+			  icecastServer.setMetadata(metadata.minm + (metadata.asar ? ' - ' + metadata.asar : '') + (metadata.asal ? ' (' + metadata.asal +  ')' : ''));
+		  });
+
+		  airplayServer.on('clientDisconnected', function() {
+			icecastServer.stop();
+		  });
+
+		  icecastServer.start(port);
+
+		  device.play({
+			uri: 'x-rincon-mp3radio://' + ip.address() + ':' + port + '/listen.m3u',
+			metadata: '<?xml version="1.0"?>' +
+			  '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">' +
+			  '<item id="R:0/0/49" parentID="R:0/0" restricted="true">' +
+			  '<dc:title>' + clientName + '</dc:title>' +
+			  '<upnp:class>object.item.audioItem.audioBroadcast</upnp:class>' +
+			  '<desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc>' +
+			  '</item>' +
+			  '</DIDL-Lite>'
+		  });
+
+		});
+	  });
+
+	  airplayServer.on('clientDisconnected', function() {
+		device.stop(function() {});
+	  });
+
+	  airplayServer.on('volumeChange', function(vol) {
+		vol = 100 - Math.floor(-1 * (Math.max(vol, -30) / 30) * 100);
+		device.setVolume(vol, function() {
+		  // ?
+		});
+	  });
+
+	  airplayServer.start();
+
+	});
+};
 
 if (flags.get('version')) {
 
@@ -23,95 +112,22 @@ if (flags.get('version')) {
   var diag = require('./diagnostics');
   diag();
 
+} else if (flags.get('devices').length > 0) {
+	var useDevices = flags.get('devices');
+	for(var i = 0; i < useDevices.length ; i++) {
+		var ipPortSplit = useDevices[i].split(':');
+		var sonosDevice;
+		if (ipPortSplit.length > 1) {
+			sonosDevice = new sonos.Sonos(ipPortSplit[0], ipPortSplit[1]);
+		} else {
+			sonosDevice = new sonos.Sonos(useDevices[i]);
+		}
+		
+		setupSonos(sonosDevice, 'Sonos'+i);
+	}
+	
 } else {
 
   console.log('Searching for Sonos devices on network...');
-  sonos.search(function(device, model) {
-
-    if (model === 'BR100' || model === 'ANVIL') return; // ignore Sonos Bridge and Sub device
-
-    device.getZoneAttrs(function(err, zoneAttrs) {
-      if (err) throw err;
-
-      var deviceName = zoneAttrs.CurrentZoneName;
-
-      console.log('Setting up AirSonos for', deviceName, '{' + device.host + ':' + device.port + '}');
-
-      var airplayServer = new NodeTunes({
-        serverName: deviceName + ' (AirSonos)',
-        verbose: flags.get('verbose'),
-        controlTimeout: flags.get('timeout')
-      });
-
-      var clientName = 'AirSonos';
-      airplayServer.on('clientNameChange', function(name) {
-        clientName = 'AirSonos @ ' + name;
-      });
-
-      airplayServer.on('error', function(err) {
-        if (err.code === 415) {
-          console.error('Warning!', err.message);
-          console.error('AirSonos currently does not support codecs used by applications such as iTunes or AirFoil.');
-          console.error('Progress on this issue: https://github.com/stephen/nodetunes/issues/1');
-        } else {
-          console.error('Unknown error:');
-          console.error(err);
-        }
-      })
-
-      airplayServer.on('clientConnected', function(audioStream) {
-
-        portastic.find({
-          min : 8000,
-          max : 8050,
-          retrieve: 1
-        }, function(err, port) {
-          if (err) throw err;
-
-          var icecastServer = new Nicercast(audioStream, {
-            name: 'AirSonos @ ' + deviceName
-          });
-
-          airplayServer.on('metadataChange', function(metadata) {
-            if (metadata.minm)
-              icecastServer.setMetadata(metadata.minm + (metadata.asar ? ' - ' + metadata.asar : '') + (metadata.asal ? ' (' + metadata.asal +  ')' : ''));
-          });
-
-          airplayServer.on('clientDisconnected', function() {
-            icecastServer.stop();
-          });
-
-          icecastServer.start(port);
-
-          device.play({
-            uri: 'x-rincon-mp3radio://' + ip.address() + ':' + port + '/listen.m3u',
-            metadata: '<?xml version="1.0"?>' +
-              '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">' +
-              '<item id="R:0/0/49" parentID="R:0/0" restricted="true">' +
-              '<dc:title>' + clientName + '</dc:title>' +
-              '<upnp:class>object.item.audioItem.audioBroadcast</upnp:class>' +
-              '<desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc>' +
-              '</item>' +
-              '</DIDL-Lite>'
-          });
-
-        });
-      });
-
-      airplayServer.on('clientDisconnected', function() {
-        device.stop(function() {});
-      });
-
-      airplayServer.on('volumeChange', function(vol) {
-        vol = 100 - Math.floor(-1 * (Math.max(vol, -30) / 30) * 100);
-        device.setVolume(vol, function() {
-          // ?
-        });
-      });
-
-      airplayServer.start();
-
-    });
-
-  });
+  sonos.search(setupSonos);
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -113,17 +113,35 @@ if (flags.get('version')) {
   diag();
 
 } else if (flags.get('devices').length > 0) {
-	var useDevices = flags.get('devices');
-	for(var i = 0; i < useDevices.length ; i++) {
-		var ipPortSplit = useDevices[i].split(':');
+	
+	var deviceArguments = flags.get('devices');
+	for(var i = 0; i < deviceArguments.length ; i++) {
+		
+		var deviceArg = deviceArguments[i];
+		
+		// set up a domain to catch errors from setting up individual
+		// devices. For example it catches the timeout when non-existing IPs
+		// are entered.
+		var setupDomain = require('domain').create();
+		setupDomain.on('error', function(err) {
+			console.error('error on setting up device "'+deviceArg+'": '+err);
+		});
+		
 		var sonosDevice;
+		
+		// Check if the argument contains a port specifier
+		var ipPortSplit = deviceArg.split(':');
 		if (ipPortSplit.length > 1) {
 			sonosDevice = new sonos.Sonos(ipPortSplit[0], ipPortSplit[1]);
 		} else {
-			sonosDevice = new sonos.Sonos(useDevices[i]);
+			sonosDevice = new sonos.Sonos(deviceArg);
 		}
 		
-		setupSonos(sonosDevice, 'Sonos'+i);
+		// run the setup in a domain so we can catch errors for each device
+		// individually:
+		setupDomain.run(function() {
+			setupSonos(sonosDevice, 'Sonos'+i);
+		});
 	}
 	
 } else {

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,7 @@ flags.defineBoolean('diagnostics', false, 'run diagnostics utility');
 flags.defineBoolean('version', false, 'return version number');
 flags.defineInteger('timeout', 5, 'disconnect timeout (in seconds)');
 flags.defineBoolean('verbose', false, 'show verbose output');
-flags.defineStringList('devices', [], 'a comma seperated list of IP[:port] values where Sonos devices can be found, disables discovery')
+flags.defineStringList('devices', [], 'a comma separated list of IP[:port] values where Sonos devices can be found, disables discovery');
 flags.parse();
 
 var setupSonos = function(device, model) {


### PR DESCRIPTION
> I am fairly new to node.js. This is in fact my first step into this language. So if i have missed some conventions or you have suggestions how i could make this better, just tell me, highly appreciated.

This adds the argument '--devices' to airsonos. The argument takes a comma separated list of IP addresses. airsonos tries to setup these without doing a discovery via M-SEARCH.

Usage:
```
node airsonos/ --devices <comma-separated list of IP[:Port]>
```

Example:
```
node airsonos/ --devices 192.168.0.100,192.168.0.101:1401
```
tries to setup airsonos with Sonos devices at IPs 192.168.0.100 and 192.168.0.101. While it connects to .100 over the standard port (1400), it connects to .101 over port 1401.

if a timeout occurs to one ore more devices, airsonos prints an error message, but maintains connection to other devices.


