### PR TITLE
Added ability to specify interface and pass ip address to nicercast/nodetunes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,10 +7,36 @@ var NodeTunes = require('nodetunes');
 var Nicercast = require('nicercast');
 var flags = require('flags');
 
+function getIPAddress(iface) {
+  var interfaces = require('os').networkInterfaces();
+  
+  if(iface != null)
+  {
+    if(interfaces[iface] == null)
+      return null;
+    var interfaces = {interface: interfaces[iface]};
+  }
+
+  for (var devName in interfaces) {
+    var iface = interfaces[devName];
+
+
+    for (var i = 0; i < iface.length; i++) {
+      var alias = iface[i];
+      if (alias.family === 'IPv4' )
+      {
+        return alias.address;
+      }
+
+    }
+  }
+}
+
 flags.defineBoolean('diagnostics', false, 'run diagnostics utility');
 flags.defineBoolean('version', false, 'return version number');
 flags.defineInteger('timeout', 5, 'disconnect timeout (in seconds)');
 flags.defineBoolean('verbose', false, 'show verbose output');
+flags.defineString('interface', false, 'network interface to bind to');
 flags.parse();
 
 if (flags.get('version')) {
@@ -24,6 +50,23 @@ if (flags.get('version')) {
   diag();
 
 } else {
+
+  var ipAddress = null
+
+  if(flags.get('interface'))
+  {
+    console.log('Using interface',flags.get('interface'));
+    //Find the IP of the specified interface
+    ipAddress = getIPAddress(flags.get('interface'))
+  }
+  else
+  {
+    //Use original method of determining IP
+    ipAddress = ip.address()
+  }
+  
+  console.log('Binding to ',ipAddress);  
+
 
   console.log('Searching for Sonos devices on network...');
   sonos.search(function(device, model) {
@@ -40,7 +83,8 @@ if (flags.get('version')) {
       var airplayServer = new NodeTunes({
         serverName: deviceName + ' (AirSonos)',
         verbose: flags.get('verbose'),
-        controlTimeout: flags.get('timeout')
+        controlTimeout: flags.get('timeout'),
+        ipAddress : ipAddress
       });
 
       var clientName = 'AirSonos';
@@ -69,7 +113,8 @@ if (flags.get('version')) {
           if (err) throw err;
 
           var icecastServer = new Nicercast(audioStream, {
-            name: 'AirSonos @ ' + deviceName
+            name: 'AirSonos @ ' + deviceName,
+            ipAddress: ipAddress
           });
 
           airplayServer.on('metadataChange', function(metadata) {
@@ -84,7 +129,7 @@ if (flags.get('version')) {
           icecastServer.start(port);
 
           device.play({
-            uri: 'x-rincon-mp3radio://' + ip.address() + ':' + port + '/listen.m3u',
+            uri: 'x-rincon-mp3radio://' + ipAddress + ':' + port + '/listen.m3u',
             metadata: '<?xml version="1.0"?>' +
               '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">' +
               '<item id="R:0/0/49" parentID="R:0/0" restricted="true">' +


### PR DESCRIPTION
I added the ability to specify an interface to bind to instead of relying on ip.address(). This was used to solve airsonos #27. This relies on an ip address option being added to nicercast and nodetunes which I submitted pull requests for as well (nicercast: stephen/nicercast#7, nodetunes: stephen/nodetunes#26). 

Example useage: 
airsonos --interface en0 # Will bind to the ip address of en0
airsonos # Will bind to the ip returned from ip.address(), i.e. legacy behavior

Note: the package.json file in this project would need to be updated to reference the updated versions of nodetunes and nicercast 