### PR TITLE
Dockerfile with Node.js 0.10.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:0.10.36
+
+RUN apt-get update && apt-get install -y libavahi-compat-libdnssd-dev
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ $ node index.js
 
 Internally, AirSonos is a thin wrapper around the [nodetunes](https://github.com/stephen/nodetunes) and [nicercast](https://github.com/stephen/nicercast) packages.
 
+Docker
+------
+
+The repo includes a `Dockerfile` to spin up a docker instance with the latest
+supported node.js version. This commands should get you up and running:
+
+```sh
+docker build -t airsonos .
+docker run airsonos
+```
+
 Changelog
 ---------
 


### PR DESCRIPTION
For anyone having trouble running `airsonos` on `node 0.12`. This Dockerfile sets up a container with `node 0.10.36` which should work with airsonos.

@stephen we should probably have someone test this before merge

Call to action: please help test!

```sh
git clone https://github.com/LinusU/airsonos.git
cd airsonos
git checkout docker
docker build -t airsonos .
docker run airsonos
```

**OS support:** this currently only works on linux. This is because of how docker works on other platforms. It runs a virtual machine that gets it's own private network with just the server and the virtual machine. This makes avahi/zeroconf/bonjour unavailable...