### PR TITLE
Search for devices without logical grouping

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,92 +26,88 @@ if (flags.get('version')) {
 } else {
 
   console.log('Searching for Sonos devices on network...');
-  sonos.LogicalDevice.search(function(err, devices) {
-    devices.forEach(function(device) {
+  sonos.search(function(device, model) {
+    device.getZoneAttrs(function(err, zoneAttrs) {
+      if (err) throw err;
 
-      device.getZoneAttrs(function(err, zoneAttrs) {
-        if (err) throw err;
+      var deviceName = zoneAttrs.CurrentZoneName;
 
-        var deviceName = zoneAttrs.CurrentZoneName;
+      console.log('Setting up AirSonos for', deviceName, '{' + device.host + ':' + device.port + '}');
 
-        console.log('Setting up AirSonos for', deviceName, '{' + device.host + ':' + device.port + '}');
-
-        var airplayServer = new NodeTunes({
-          serverName: deviceName + ' (AirSonos)',
-          verbose: flags.get('verbose'),
-          controlTimeout: flags.get('timeout')
-        });
-
-        var clientName = 'AirSonos';
-        airplayServer.on('clientNameChange', function(name) {
-          clientName = 'AirSonos @ ' + name;
-        });
-
-        airplayServer.on('error', function(err) {
-          if (err.code === 415) {
-            console.error('Warning!', err.message);
-            console.error('AirSonos currently does not support codecs used by applications such as iTunes or AirFoil.');
-            console.error('Progress on this issue: https://github.com/stephen/nodetunes/issues/1');
-          } else {
-            console.error('Unknown error:');
-            console.error(err);
-          }
-        })
-
-        airplayServer.on('clientConnected', function(audioStream) {
-
-          portastic.find({
-            min : 8000,
-            max : 8050,
-            retrieve: 1
-          }, function(err, port) {
-            if (err) throw err;
-
-            var icecastServer = new Nicercast(audioStream, {
-              name: 'AirSonos @ ' + deviceName
-            });
-
-            airplayServer.on('metadataChange', function(metadata) {
-              if (metadata.minm)
-                icecastServer.setMetadata(metadata.minm + (metadata.asar ? ' - ' + metadata.asar : '') + (metadata.asal ? ' (' + metadata.asal +  ')' : ''));
-            });
-
-            airplayServer.on('clientDisconnected', function() {
-              icecastServer.stop();
-            });
-
-            icecastServer.start(port);
-
-            device.play({
-              uri: 'x-rincon-mp3radio://' + ip.address() + ':' + port + '/listen.m3u',
-              metadata: '<?xml version="1.0"?>' +
-                '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">' +
-                '<item id="R:0/0/49" parentID="R:0/0" restricted="true">' +
-                '<dc:title>' + clientName + '</dc:title>' +
-                '<upnp:class>object.item.audioItem.audioBroadcast</upnp:class>' +
-                '<desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc>' +
-                '</item>' +
-                '</DIDL-Lite>'
-            });
-
-          });
-        });
-
-        airplayServer.on('clientDisconnected', function() {
-          device.stop(function() {});
-        });
-
-        airplayServer.on('volumeChange', function(vol) {
-          vol = 100 - Math.floor(-1 * (Math.max(vol, -30) / 30) * 100);
-          device.setVolume(vol, function() {
-            // ?
-          });
-        });
-
-        airplayServer.start();
-
+      var airplayServer = new NodeTunes({
+        serverName: deviceName + ' (AirSonos)',
+        verbose: flags.get('verbose'),
+        controlTimeout: flags.get('timeout')
       });
-    });
 
+      var clientName = 'AirSonos';
+      airplayServer.on('clientNameChange', function(name) {
+        clientName = 'AirSonos @ ' + name;
+      });
+
+      airplayServer.on('error', function(err) {
+        if (err.code === 415) {
+          console.error('Warning!', err.message);
+          console.error('AirSonos currently does not support codecs used by applications such as iTunes or AirFoil.');
+          console.error('Progress on this issue: https://github.com/stephen/nodetunes/issues/1');
+        } else {
+          console.error('Unknown error:');
+          console.error(err);
+        }
+      })
+
+      airplayServer.on('clientConnected', function(audioStream) {
+
+        portastic.find({
+          min : 8000,
+          max : 8050,
+          retrieve: 1
+        }, function(err, port) {
+          if (err) throw err;
+
+          var icecastServer = new Nicercast(audioStream, {
+            name: 'AirSonos @ ' + deviceName
+          });
+
+          airplayServer.on('metadataChange', function(metadata) {
+            if (metadata.minm)
+              icecastServer.setMetadata(metadata.minm + (metadata.asar ? ' - ' + metadata.asar : '') + (metadata.asal ? ' (' + metadata.asal +  ')' : ''));
+          });
+
+          airplayServer.on('clientDisconnected', function() {
+            icecastServer.stop();
+          });
+
+          icecastServer.start(port);
+
+          device.play({
+            uri: 'x-rincon-mp3radio://' + ip.address() + ':' + port + '/listen.m3u',
+            metadata: '<?xml version="1.0"?>' +
+              '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">' +
+              '<item id="R:0/0/49" parentID="R:0/0" restricted="true">' +
+              '<dc:title>' + clientName + '</dc:title>' +
+              '<upnp:class>object.item.audioItem.audioBroadcast</upnp:class>' +
+              '<desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc>' +
+              '</item>' +
+              '</DIDL-Lite>'
+          });
+
+        });
+      });
+
+      airplayServer.on('clientDisconnected', function() {
+        device.stop(function() {});
+      });
+
+      airplayServer.on('volumeChange', function(vol) {
+        vol = 100 - Math.floor(-1 * (Math.max(vol, -30) / 30) * 100);
+        device.setVolume(vol, function() {
+          // ?
+        });
+      });
+
+      airplayServer.start();
+
+    });
   });
 }


### PR DESCRIPTION
This should fix #31. I don't know why `sonos.search` and `sonos.LogicalDevice` are used in different places, but I can see that we don't seem to use the `err` parameter from the second variant, so no value seem to be lost to me.

Of course, just because it works in my setup does not guarantee that new problems aren't introduced. An alternative solution is to keep track of the IP + port pairs we've already set up and not do it more than once if we see any duplicates.

What do you think?

**Tip:** Append `?w=1` to the URL to see a diff that ignore whitespace changes.