### PR TITLE
Duplicate device hack

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,6 +26,7 @@ if (flags.get('version')) {
 } else {
 
   console.log('Searching for Sonos devices on network...');
+  var deviceList = [];
   sonos.LogicalDevice.search(function(err, devices) {
     devices.forEach(function(device) {
 
@@ -34,6 +35,13 @@ if (flags.get('version')) {
 
         var deviceName = zoneAttrs.CurrentZoneName;
 
+        if(deviceList.indexOf(device.host + ':' + device.port) >= 0) {
+          if (flags.get('verbose')) {
+            console.log('Skipping duplicate device found at',deviceName, '{' + device.host + ':' + device.port + '}');
+          }
+          return;
+        }
+        deviceList.push(device.host + ':' + device.port)
         console.log('Setting up AirSonos for', deviceName, '{' + device.host + ':' + device.port + '}');
 
         var airplayServer = new NodeTunes({


### PR DESCRIPTION
Preface:  I've never written a line of Node before.  

All I'm doing here is keeping track of what devices have been added so far, and skipping anything that's already been found.  "First one wins".  This is a complete and total hack, and probably should not be merged.

The proper fix is somewhere in node-sonos in the LogicalDevice.search method, but that was way over my head.  With any luck, this might fix issue stephen/airsonos#114 - that's the itch I'm trying to scratch.  There's a large chance it may not.