### PR TITLE
Fix: Speakers appear multiple times #114

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,29 @@ flags.defineInteger('timeout', 5, 'disconnect timeout (in seconds)');
 flags.defineBoolean('verbose', false, 'show verbose output');
 flags.parse();
 
+var airplayEnabledDevices = [];
+
+var uniqueDeviceIdFromDevice = function(device) {
+  return device.host+':'+device.port;
+}
+
+var isDeviceAirplayEnabled = function(device){
+  return (airplayEnabledDevices.indexOf(uniqueDeviceIdFromDevice(device)) >= 0);
+}
+
+var addDeviceToEnabledList = function(device){
+  if (!isDeviceAirplayEnabled(uniqueDeviceIdFromDevice(device))) {
+    airplayEnabledDevices.push(uniqueDeviceIdFromDevice(device));
+  }
+}
+
+// Commented out while not in use until some event for Sonos device disappeared are available
+/*var removeDeviceFromEnabledList = function(device){
+  if (isDeviceAirplayEnabled(uniqueDeviceIdFromDevice(device))) {
+    airplayEnabledDevices.splice(airplayEnabledDevices.indexOf(uniqueDeviceIdFromDevice(device)),1);
+  }  
+}*/
+
 if (flags.get('version')) {
 
   var pjson = require('../package.json');
@@ -28,6 +51,15 @@ if (flags.get('version')) {
   console.log('Searching for Sonos devices on network...');
   sonos.LogicalDevice.search(function(err, devices) {
     devices.forEach(function(device) {
+
+      // Avoid duplicates
+      if (isDeviceAirplayEnabled(device)) {
+        if (flags.get('verbose')) 
+          console.log('Found Sonos device:', '{' + device.host + ':' + device.port + '}', 'seen before - skipping it');
+        return;
+      } else {
+        addDeviceToEnabledList(device);
+      }
 
       device.getZoneAttrs(function(err, zoneAttrs) {
         if (err) throw err;


### PR DESCRIPTION
Added functionality that keeps tracks of Sonos devices that already been created AirPlay servers for. Skip creating a new AirPlay server when a discovered Sonos device is a duplicate  