### PR TITLE
Fix issues #222, #248 by updating ip package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel": "^5.8.21",
     "bluebird": "^2.9.34",
     "flags": "~0.1.2",
-    "ip": "0.3.2",
+    "ip": "1.1.0",
     "nicercast": "0.1.0",
     "nodetunes": "^0.3.0",
     "sonos": "git://github.com/stephen/node-sonos.git#stephen-1.0.0"


### PR DESCRIPTION
node-ip v1.1 includes a fix for correctly identifying loopback IP addresses i.e. skipping OpenVPN addresses 127.94.0.1 & 127.94.0.2.

(see https://github.com/indutny/node-ip/commit/3fb5e07921cfb2c8f2cda1c96f627e3c7d1ee57b)