### PR TITLE
Improve Title Metadata with actual Client name

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -26,6 +26,7 @@ class DeviceTunnel extends events.EventEmitter {
     this.device = device;
     this.deviceName = deviceName;
     this.options = options;
+    this.clientName = 'AirSonos';
 
     this.bindAirplayServer();
   }
@@ -38,9 +39,8 @@ class DeviceTunnel extends events.EventEmitter {
 
     this.airplayServer.on('error', this.emit.bind(this, 'error'));
 
-    let clientName = 'AirSonos';
     this.airplayServer.on('clientNameChange', (name) => {
-      clientName = `AirSonos @ ${ name }`;
+      this.clientName = `AirSonos @ ${ name }`;
     });
 
     this.airplayServer.on('clientConnected', this.handleClientConnected.bind(this));
@@ -75,7 +75,7 @@ class DeviceTunnel extends events.EventEmitter {
     this.icecastServer.start(0, (port) => {
       this.device.play({
         uri: `x-rincon-mp3radio://${ ip.address() }:${ port }/listen.m3u`,
-        metadata: this.generateSonosMetadata(this.deviceName),
+        metadata: this.generateSonosMetadata(this.clientName),
       });
     });
   }


### PR DESCRIPTION
Currently, the "deviceName" is sent as the Title of the stream.
This change creates a new property for the Tunnel with the name of the client, defaulted to AirSonos, as in previous versions of AirSonos