### PR TITLE
Make platform notes in README more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Installation
 
 AirSonos requires [node.js](http://nodejs.org) >= v0.10.33 installed to run.
 
+### macOS Installation
+
 Install via [npm](https://www.npmjs.org)
 ```
 $ npm install airsonos -g
 ```
+
+### Other Platforms
 
 Platform-specific install note available from [`INSTALL.md`](https://github.com/stephen/airsonos/blob/master/INSTALL.md)
 


### PR DESCRIPTION
This might help people like me who try a bunch of different node versions to get `npm install -g airsonos` to work before noticing the platform-specific notes.